### PR TITLE
job-occupation in seed.rb should be compatible with new standard

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,6 @@ user.confirmed_at = Time.now
 user.save
 
 job = Job.create!( :title => "Rails developer", :url => "http://ruby.tw", 
-                   :company_name => "Ruby Taiwan", :job_type => "Full-time", :occupation => "Back-end",
+                   :company_name => "Ruby Taiwan", :job_type => "Full-time", :occupation => "Web back-end",
                    :location => "Taipei", :user_id => 1,
                    :description => "This is awesome job!<br>The salary is also great!", :apply_information => "Please email to me" )


### PR DESCRIPTION
in commit b5f4acf306b217d6a57fd457bbcad827a088235c , valid `OCCUPATION` in Job model has been changed, but missed `db/seed.rb` , which causes problems when running `rake db:seed`.  This commit fixes the issue.
